### PR TITLE
Fix "Default Error Handler" example code

### DIFF
--- a/_guide/100. ng1-migration-to-1.0-from-legacy.md
+++ b/_guide/100. ng1-migration-to-1.0-from-legacy.md
@@ -387,9 +387,9 @@ Because of this, errors that were silent in your legacy app may start making som
 To revert this behavior, or customize it, provide your own custom `defaultErrorHandler` implementation.
 
 ```js
-app.config(function($stateProvider) {
+app.run(function($state) {
   window.myAppErrorLog = [];
-  $stateProvider.stateService.defaultErrorHandler(function(error) {
+  $state.defaultErrorHandler(function(error) {
     // This is a naive example of how to silence the default error handler.
     window.myAppErrorLog.push(error);
   });

--- a/_guide/100. ng1-migration-to-1.0-from-legacy.md
+++ b/_guide/100. ng1-migration-to-1.0-from-legacy.md
@@ -389,7 +389,7 @@ To revert this behavior, or customize it, provide your own custom `defaultErrorH
 ```js
 app.config(function($stateProvider) {
   window.myAppErrorLog = [];
-  $stateProvider.defaultErrorHandler(function(error) {
+  $stateProvider.stateService.defaultErrorHandler(function(error) {
     // This is a naive example of how to silence the default error handler.
     window.myAppErrorLog.push(error);
   });


### PR DESCRIPTION
Original code doesn't work throwing `TypeError: $stateProvider.defaultErrorHandler is not a function`