### PR TITLE
Update unpkg CDN snippets on about pages

### DIFF
--- a/_ng1/about.md
+++ b/_ng1/about.md
@@ -33,8 +33,8 @@ Other examples:
   - Adding a specific version to your project: `npm install --save angular-ui-router@1.0.0-beta.1`
   
 - From <http://unpkg.com> via a `<script>` tag in your html: 
-  - Latest stable version: `<script src="//unpkg.com/angular-ui-router/release/angular-ui-router.min.js">`
-  - A specific version: `<script src="//unpkg.com/angular-ui-router@0.3.1/release/angular-ui-router.js">`
+  - Latest stable version: `<script src="//unpkg.com/angular-ui-router/release/angular-ui-router.min.js"></script>`
+  - A specific version: `<script src="//unpkg.com/angular-ui-router@0.3.1/release/angular-ui-router.js"></script>`
   
 - From bower: `bower install angular-ui-router#0.3.1`
 

--- a/_ng2/about.md
+++ b/_ng2/about.md
@@ -26,8 +26,8 @@ Other examples:
 
 - Adding a specific version to your project: `npm install --save ui-router-ng2@1.0.0-beta.1`
 - From <http://unpkg.com> via a `<script>` tag in your html: 
-  - Latest stable version: `<script src="//unpkg.com/ui-router-ng2/_bundles/ui-router-ng2.js">`
-  - A specific version: `<script src="//unpkg.com/ui-router-ng2@1.0.0-beta.1/_bundles/ui-router-ng2.js">`
+  - Latest stable version: `<script src="//unpkg.com/ui-router-ng2/_bundles/ui-router-ng2.js"></script>`
+  - A specific version: `<script src="//unpkg.com/ui-router-ng2@1.0.0-beta.1/_bundles/ui-router-ng2.js"></script>`
 
 ## Tutorials
 


### PR DESCRIPTION
Hi,

This updates the ng1 and ng2 about pages to add closing script tags to the CDN code snippets.

When I was making a plnkr recently, I copied and pasted directly from the ng1 about page, and it took me a little too long to figure out why the next script wasn't loading. Hopefully this saves others the hassle.