### PR TITLE
Add jsDelivr links

### DIFF
--- a/_ng1/about.md
+++ b/_ng1/about.md
@@ -31,6 +31,11 @@ Other examples:
 - Via command line
   - Adding a specific version to your project: `npm install --save @uirouter/angularjs@1.0.7`
   
+- From [http://jsdelivr.com](https://www.jsdelivr.com/package/npm/@uirouter/angularjs) via a `<script>` tag in your html:
+  - Latest stable version: `<script src="//cdn.jsdelivr.net/npm/@uirouter/angularjs/release/angular-ui-router.min.js"></script>`
+  - A specific version: `<script src="//cdn.jsdelivr.net/npm/@uirouter/angularjs@1.0.7/release/angular-ui-router.min.js"></script>`
+  - A legacy version: `<script src="//cdn.jsdelivr.net/npm/angular-ui-router@0.4.2/release/angular-ui-router.js"></script>`
+  
 - From <http://unpkg.com> via a `<script>` tag in your html: 
   - Latest stable version: `<script src="//unpkg.com/@uirouter/angularjs/release/angular-ui-router.min.js"></script>`
   - A specific version: `<script src="//unpkg.com/@uirouter/angularjs@1.0.7/release/angular-ui-router.min.js"></script>`

--- a/_ng2/about.md
+++ b/_ng2/about.md
@@ -25,6 +25,9 @@ npm install --save ui-router-ng2
 Other examples:
 
 - Adding a specific version to your project: `npm install --save ui-router-ng2@1.0.0-beta.1`
+- From [http://jsdelivr.com](https://www.jsdelivr.com/package/npm/ui-router-ng2) via a `<script>` tag in your html:
+  - Latest stable version: `<script src="//cdn.jsdelivr.net/npm/ui-router-ng2/_bundles/ui-router-ng2.js"></script>`
+  - A specific version: `<script src="//cdn.jsdelivr.net/npm/ui-router-ng2@1.0.0-beta.1/_bundles/ui-router-ng2.js"></script>`
 - From <http://unpkg.com> via a `<script>` tag in your html: 
   - Latest stable version: `<script src="//unpkg.com/ui-router-ng2/_bundles/ui-router-ng2.js"></script>`
   - A specific version: `<script src="//unpkg.com/ui-router-ng2@1.0.0-beta.1/_bundles/ui-router-ng2.js"></script>`


### PR DESCRIPTION
I added jsDelivr CDN links to your site as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability. We also have detailed usage stats for project maintainers.