### PR TITLE
Completed incomplete script tag

### DIFF
--- a/_ng1_tutorial/helloworld.md
+++ b/_ng1_tutorial/helloworld.md
@@ -93,7 +93,7 @@ Create a new script `helloworld.js` for the application code and add a script ta
 <head>
   <script src="lib/angular.js"></script>
   <script src="lib/angular-ui-router.js"></script>
-  <script src="helloworld.js"</script>
+  <script src="helloworld.js"></script>
 </head>
 ```
 


### PR DESCRIPTION
The last script tag was not complete, through this the linting of the formatted code was wrong. Furthermore it could happen that some browsers don't automatically close the tag in a right way, than you end up not seeing the example using copy&paste.