### PR TITLE
locking jekyll container version to 4.2.0.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -165,7 +165,7 @@ timezone: # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
 # Plugins
-gems:
+plugins:
   - jekyll-redirect-from
   - jekyll-paginate
   - jekyll-sitemap

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build:css": "npm run scss && npm run autoprefixer",
     "build:js": "npm run uglify",
     "build:all": "npm run build:css && build:js",
-    "serve": "docker run -p 4000:4000 --volume=\"$PWD:/srv/jekyll\" -it jekyll/jekyll:latest jekyll serve --incremental --watch",
+    "serve": "docker run -p 4000:4000 --volume=\"$PWD:/srv/jekyll\" -it jekyll/jekyll:4.2.0 jekyll serve --incremental --watch",
     "start": "npm run watch:all & npm run serve"
   }
 }


### PR DESCRIPTION
Hi @christopherthielen! is been a while, but I've been working to fix the Docs when I had some time. This is the first of a series of PRs across several projects that focus on fixing the Docs generation scripts and containers. For now I will only focus on the @uirouter/angular package, but I'll check the rest later on. 

This one is simple, is just replacing the :latest tag for :4.2.0 tag for jekyll container so the serve script works. the latest versions of the container is not working well with the current configuration of the project.

Also, as I've been building the docs locally I have a separated branch that contains the built _ng2_docs for v21. If you like I can add another PR, this will make it easy for you to publish the docs. Regardless, I'll be adding the changes needed to fix the tasks soon!

Kind Regards 